### PR TITLE
Fix es2015 error on React Native projects

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+/node_modules
+/src/grammar.js
+.babelrc


### PR DESCRIPTION
The .babelrc file shouldn't be published to npm.