### PR TITLE
Resolves #11 by only outputting borderRadius prop

### DIFF
--- a/dist/grammar.js
+++ b/dist/grammar.js
@@ -226,8 +226,9 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
         return [d[0]].concat(d[1]);
       } }, { "name": "borderColor", "symbols": ["color", "borderColor$ebnf$1"], "postprocess": combineClockwiseShorthand('border', undefined, 'Color') }, { "name": "borderRadius$ebnf$1", "symbols": [] }, { "name": "borderRadius$ebnf$1$subexpression$1", "symbols": ["_", "number"] }, { "name": "borderRadius$ebnf$1", "symbols": ["borderRadius$ebnf$1$subexpression$1", "borderRadius$ebnf$1"], "postprocess": function arrconcat(d) {
         return [d[0]].concat(d[1]);
-      } }, { "name": "borderRadius", "symbols": ["number", "borderRadius$ebnf$1"], "postprocess": combineClockwiseShorthand('border', ['TopLeft', 'TopRight', 'BottomRight', 'BottomLeft'], 'Radius')
-    }, { "name": "flexFlowFlexWrap$subexpression$1$string$1", "symbols": [{ "literal": "n" }, { "literal": "o" }, { "literal": "w" }, { "literal": "r" }, { "literal": "a" }, { "literal": "p" }], "postprocess": function joiner(d) {
+      } }, { "name": "borderRadius", "symbols": ["number", "borderRadius$ebnf$1"], "postprocess": function postprocess(d) {
+        return { $merge: { borderRadius: d[0] } };
+      } }, { "name": "flexFlowFlexWrap$subexpression$1$string$1", "symbols": [{ "literal": "n" }, { "literal": "o" }, { "literal": "w" }, { "literal": "r" }, { "literal": "a" }, { "literal": "p" }], "postprocess": function joiner(d) {
         return d.join('');
       } }, { "name": "flexFlowFlexWrap$subexpression$1", "symbols": ["flexFlowFlexWrap$subexpression$1$string$1"] }, { "name": "flexFlowFlexWrap$subexpression$1$string$2", "symbols": [{ "literal": "w" }, { "literal": "r" }, { "literal": "a" }, { "literal": "p" }], "postprocess": function joiner(d) {
         return d.join('');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-to-react-native",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Convert CSS text to a React Native stylesheet object",
   "main": "dist/index.js",
   "scripts": {

--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -143,9 +143,7 @@ borderColor
   -> color (_ color):* {% combineClockwiseShorthand('border', undefined, 'Color') %}
 
 borderRadius
-  -> number (_ number):* {%
-       combineClockwiseShorthand('border', ['TopLeft', 'TopRight', 'BottomRight', 'BottomLeft'], 'Radius')
-     %}
+  -> number (_ number):* {% (d) => ({ $merge: { borderRadius: d[0] } }) %}
 
 flexFlowFlexWrap -> ("nowrap" | "wrap" | "wrap-reverse") {% text %}
 flexFlowFlexDirection -> ("row" | "row-reverse" | "column" | "column-reverse") {% text %}

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -20,19 +20,13 @@ it('allows decimal values', () => runTest([
 it('allows decimal values in transformed values', () => runTest([
   ['border-radius', '1.5'],
 ], {
-  borderTopLeftRadius: 1.5,
-  borderTopRightRadius: 1.5,
-  borderBottomRightRadius: 1.5,
-  borderBottomLeftRadius: 1.5,
+  borderRadius: 1.5,
 }));
 
 it('allows negative values in transformed values', () => runTest([
   ['border-radius', '-1.5'],
 ], {
-  borderTopLeftRadius: -1.5,
-  borderTopRightRadius: -1.5,
-  borderBottomRightRadius: -1.5,
-  borderBottomLeftRadius: -1.5,
+  borderRadius: -1.5,
 }));
 
 it('transforms strings', () => runTest([


### PR DESCRIPTION
Change grammar to only output `borderRadius` instead of `borderTopLeftRadius` etc. which doesn't seem to have an effect when developing for native.

One solution could be to output them all together to cover all bases but I'm not sure if this is necessary.

Would be happy to update if you'd rather it included all props though :smile:

The tests pass and as stated in my original issue [here](https://github.com/styled-components/styled-components/issues/248) only using `borderRadius` works as expected within native and this was the case with `styled-components` version `1.0.11`.

@jh3y