### PR TITLE
Fix border properties on Image component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,6 @@ const grammar = require('./grammar');
 const transforms = [
   'background',
   'border',
-  'borderColor',
-  'borderRadius',
-  'borderWidth',
   'flex',
   'flexFlow',
   'font',


### PR DESCRIPTION
For some reason, if we transform some border properties, it doesn't work on `Image`. But if we don't transform, it still works everywhere.

```
const AvatarImage = styled.Image`
  width: ${({ size }) => size};
  height: ${({ size }) => size};
  background-color: black;
  border-radius: 4;
  border-color: red;
  border-width: 5;
`;
```

```
const AvatarView = styled.View`
  width: ${({ size }) => size};
  height: ${({ size }) => size};
  background-color: black;
  border-radius: 4;
  border-color: red;
  border-width: 5;
`;
```