### PR TITLE
Remove for-of loops (fixes #31)

### DIFF
--- a/src/TokenStream.js
+++ b/src/TokenStream.js
@@ -23,8 +23,8 @@ module.exports = class TokenStream {
 
     if (!node) return null;
 
-    /* eslint-disable no-restricted-syntax */
-    for (const tokenDescriptor of tokenDescriptors) {
+    for (let i = 0; i < tokenDescriptors.length; i += 1) {
+      const tokenDescriptor = tokenDescriptors[i];
       const value = tokenDescriptor(node);
 
       if (value !== null) {
@@ -34,7 +34,6 @@ module.exports = class TokenStream {
         return value;
       }
     }
-    /* eslint-enable */
 
     return null;
   }

--- a/src/transforms/util.js
+++ b/src/transforms/util.js
@@ -45,16 +45,15 @@ module.exports.anyOrderFactory = (properties, delim = SPACE) => (tokenStream) =>
   while (numParsed < propertyNames.length && tokenStream.hasTokens()) {
     if (numParsed) tokenStream.expect(delim);
 
-    let didMatch = false;
-    for (const propertyName of propertyNames) { // eslint-disable-line
-      if (values[propertyName] === undefined && tokenStream.match(properties[propertyName].token)) {
-        values[propertyName] = tokenStream.lastValue;
-        didMatch = true;
-        break;
-      }
-    }
+    const matchedPropertyName = propertyNames.find(propertyName => (
+      values[propertyName] === undefined && tokenStream.match(properties[propertyName].token)
+    ));
 
-    if (!didMatch) tokenStream.throw();
+    if (!matchedPropertyName) {
+      tokenStream.throw();
+    } else {
+      values[matchedPropertyName] = tokenStream.lastValue;
+    }
 
     numParsed += 1;
   }


### PR DESCRIPTION
We still use the spread operator, but that seems to compile to using just `arguments`.