### PR TITLE
Add more stylesheet units for the length regex

### DIFF
--- a/src/tokenTypes.js
+++ b/src/tokenTypes.js
@@ -27,7 +27,7 @@ const identRe = /(^-?[_a-z][_a-z0-9-]*$)/i;
 // Note if these are wrong, you'll need to change index.js too
 const numberRe = /^([+-]?(?:\d*\.)?\d+(?:[Ee][+-]?\d+)?)$/;
 // Note lengthRe is sneaky: you can omit units for 0
-const lengthRe = /^(0$|(?:[+-]?(?:\d*\.)?\d+(?:[Ee][+-]?\d+)?)(?=px$))/;
+const lengthRe = /^(0$|(?:[+-]?(?:\d*\.)?\d+(?:[Ee][+-]?\d+)?)(?=(px|pt|em|ex|pc)$))/;
 const angleRe = /^([+-]?(?:\d*\.)?\d+(?:[Ee][+-]?\d+)?(?:deg|rad))$/;
 const percentRe = /^([+-]?(?:\d*\.)?\d+(?:[Ee][+-]?\d+)?%)$/;
 


### PR DESCRIPTION
Add px, pt, em, ex and pc as CSS units to detect the length. Otherwise a
pt value for instance can not be transformed.

I used the library without styled components and transform css for an htmlview. Then you can have other css units like points.