### PR TITLE
Fix DirectionFactory to support shorthand syntax without unit (Fixes #17)

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -83,12 +83,12 @@ it('allows color values in transformed border-color values', () => runTest([
 }));
 
 it('allows omitting units for 0', () => runTest([
-  ['margin', '10px 0'],
+  ['margin', '10 5'],
 ], {
   marginTop: 10,
-  marginRight: 0,
+  marginRight: 5,
   marginBottom: 10,
-  marginLeft: 0,
+  marginLeft: 5,
 }));
 
 it('transforms strings', () => runTest([
@@ -432,6 +432,6 @@ it('allows blacklisting shorthands', () => {
 });
 
 it('throws useful errors', () => {
-  expect(() => transformCss([['margin', '10']]))
-    .toThrow('Failed to parse declaration "margin: 10"');
+  expect(() => transformCss([['margin', '#fff']]))
+    .toThrow('Failed to parse declaration "margin: #fff');
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -83,12 +83,21 @@ it('allows color values in transformed border-color values', () => runTest([
 }));
 
 it('allows omitting units for 0', () => runTest([
-  ['margin', '10 5'],
+  ['margin', '10px 0'],
 ], {
   marginTop: 10,
-  marginRight: 5,
+  marginRight: 0,
   marginBottom: 10,
-  marginLeft: 5,
+  marginLeft: 0,
+}));
+
+it('allows omitting units for margin shorthand', () => runTest([
+  ['margin', '6 9'],
+], {
+  marginTop: 6,
+  marginRight: 9,
+  marginBottom: 6,
+  marginLeft: 9,
 }));
 
 it('transforms strings', () => runTest([

--- a/src/transforms/util.js
+++ b/src/transforms/util.js
@@ -1,9 +1,9 @@
 const { tokens } = require('../tokenTypes');
 
-const { LENGTH, PERCENT, SPACE } = tokens;
+const { LENGTH, PERCENT, NUMBER, SPACE } = tokens;
 
 module.exports.directionFactory = ({
-  types = [LENGTH, PERCENT],
+  types = [LENGTH, PERCENT, NUMBER],
   directions = ['Top', 'Right', 'Bottom', 'Left'],
   prefix = '',
   suffix = '',


### PR DESCRIPTION
@jacobp100 This small change will support `margin: 10` or `padding: 2 5`.
This Fixes #17