### PR TITLE
Allow CSS custom properties to be used without converting to camel case

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -47,6 +47,10 @@ it('allows undefined values', () => {
   })
 })
 
+it('allows CSS custom properties to pass through', () => {
+  expect(transformCss([['--my-prop', '0%']])).toEqual({ '--my-prop': '0%' })
+})
+
 it('allows percent in unspecialized transform', () => {
   expect(transformCss([['top', '0%']])).toEqual({ top: '0%' })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,13 @@ export const getStylesForProperty = (propName, inputValue, allowShorthand) => {
     : { [propName]: propValue }
 }
 
-export const getPropertyName = camelizeStyleName
+export const getPropertyName = propName => {
+  const isCustomProp = /^--\w+/.test(propName)
+  if (isCustomProp) {
+    return propName
+  }
+  return camelizeStyleName(propName)
+}
 
 export default (rules, shorthandBlacklist = []) =>
   rules.reduce((accum, rule) => {


### PR DESCRIPTION
Currently the parser turns any CSS property names to camel case.

There is however a use case for implementing support for [CSS Custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*). Here's an example of how custom props can be used:
https://github.com/kristerkari/react-native-stylus-transformer/issues/3#issuecomment-397918744

So if we just don't turn the custom property to camel case, everything works like it did before, but implementations of updating custom properties with Javascript are now possible.

ping @jacobp100 