### PR TITLE
line-height: throw an error when using a multiplier

### DIFF
--- a/src/__tests__/lineHeight.js
+++ b/src/__tests__/lineHeight.js
@@ -1,0 +1,13 @@
+import transformCss from '..'
+
+it('transforms line-height with value and unit', () => {
+  expect(transformCss([['line-height', '1.5px']])).toEqual({
+    lineHeight: 1.5,
+  })
+})
+
+it('throws for line-height with multiplier', () => {
+  expect(() => transformCss([['line-height', '1.5']])).toThrow(
+    'Failed to parse declaration "lineHeight: 1.5"'
+  )
+})

--- a/src/transforms/index.js
+++ b/src/transforms/index.js
@@ -64,6 +64,8 @@ const flexFlow = anyOrderFactory({
 })
 const fontVariant = tokenStream => [tokenStream.expect(IDENT)]
 const fontWeight = tokenStream => tokenStream.expect(WORD) // Also match numbers as strings
+const lineHeight = tokenStream =>
+  tokenStream.expect(LENGTH, UNSUPPORTED_LENGTH_UNIT)
 const shadowOffset = shadowOffsetFactory()
 const textShadowOffset = shadowOffsetFactory()
 
@@ -80,6 +82,7 @@ export default {
   fontFamily,
   fontVariant,
   fontWeight,
+  lineHeight,
   margin,
   padding,
   shadowOffset,


### PR DESCRIPTION
Throw an error when a multiplier is used as a value for `line-height`.

Fixes #89

@jacobp100 Let me know if you want this to be handled in a different way.