### PR TITLE
Support CSS3 Variables in font family

### DIFF
--- a/src/__tests__/font.js
+++ b/src/__tests__/font.js
@@ -120,3 +120,31 @@ it('transforms font without quotes', () => {
     lineHeight: 18,
   })
 })
+
+it('transforms font with css variables', () => {
+  expect(
+    transformCss([['font', 'bold italic small-caps 16px/18px var(--test)']])
+  ).toEqual({
+    fontFamily: 'var(--test)',
+    fontSize: 16,
+    fontWeight: 'bold',
+    fontStyle: 'italic',
+    fontVariant: ['small-caps'],
+    lineHeight: 18,
+  })
+})
+
+it('transforms font with css variables and default value', () => {
+  expect(
+    transformCss([
+      ['font', 'bold italic small-caps 16px/18px var(--test, arial)'],
+    ])
+  ).toEqual({
+    fontFamily: 'var(--test, arial)',
+    fontSize: 16,
+    fontWeight: 'bold',
+    fontStyle: 'italic',
+    fontVariant: ['small-caps'],
+    lineHeight: 18,
+  })
+})

--- a/src/__tests__/fontFamily.js
+++ b/src/__tests__/fontFamily.js
@@ -55,8 +55,8 @@ it('transforms font-family with css variable and default value', () => {
 })
 
 it('transforms font-family with css variable and default quoted value', () => {
-  expect(transformCss([['font-family', 'var(--test, \'arial\')']])).toEqual({
-    fontFamily: 'var(--test, \'arial\')',
+  expect(transformCss([['font-family', "var(--test, 'arial')"]])).toEqual({
+    fontFamily: "var(--test, 'arial')",
   })
 })
 
@@ -67,13 +67,9 @@ it('transforms font-family with css variable and two default values', () => {
 })
 
 it('does not transform font-family with css variable and invalid default value', () => {
-  expect(() =>
-    transformCss([['font-family', 'var(--test,)']])
-  ).toThrow()
+  expect(() => transformCss([['font-family', 'var(--test,)']])).toThrow()
 })
 
 it('does not transform font-family with multiple bad css variable default values', () => {
-  expect(() =>
-    transformCss([['font-family', 'var(--test,,)']])
-  ).toThrow()
+  expect(() => transformCss([['font-family', 'var(--test,,)']])).toThrow()
 })

--- a/src/__tests__/fontFamily.js
+++ b/src/__tests__/fontFamily.js
@@ -41,3 +41,39 @@ it('does not transform invalid unquoted font-family', () => {
     transformCss([['font-family', 'Goudy Bookletter 1911']])
   ).toThrow()
 })
+
+it('transforms font-family with css variable', () => {
+  expect(transformCss([['font-family', 'var(--test)']])).toEqual({
+    fontFamily: 'var(--test)',
+  })
+})
+
+it('transforms font-family with css variable and default value', () => {
+  expect(transformCss([['font-family', 'var(--test, arial)']])).toEqual({
+    fontFamily: 'var(--test, arial)',
+  })
+})
+
+it('transforms font-family with css variable and default quoted value', () => {
+  expect(transformCss([['font-family', 'var(--test, \'arial\')']])).toEqual({
+    fontFamily: 'var(--test, \'arial\')',
+  })
+})
+
+it('transforms font-family with css variable and two default values', () => {
+  expect(transformCss([['font-family', 'var(--test, hello, world)']])).toEqual({
+    fontFamily: 'var(--test, hello, world)',
+  })
+})
+
+it('does not transform font-family with css variable and invalid default value', () => {
+  expect(() =>
+    transformCss([['font-family', 'var(--test,)']])
+  ).toThrow()
+})
+
+it('does not transform font-family with multiple bad css variable default values', () => {
+  expect(() =>
+    transformCss([['font-family', 'var(--test,,)']])
+  ).toThrow()
+})

--- a/src/tokenTypes.js
+++ b/src/tokenTypes.js
@@ -11,26 +11,33 @@ const matchString = node => {
 }
 
 const matchVariable = node => {
-  if (node.type !== 'function' && node.value !== 'var' || node.nodes.length === 0) return null;
+  if (
+    (node.type !== 'function' && node.value !== 'var') ||
+    node.nodes.length === 0
+  )
+    return null
 
-  const variableName = node.nodes[0].value;
+  const variableName = node.nodes[0].value
 
   if (node.nodes.length === 1) {
-    return `var(${variableName})`;
+    return `var(${variableName})`
   }
 
-  const defaultValues = node.nodes.slice(1).filter(node => node.type !== 'div').map(subnode => {
-    if (subnode.type === 'string') {
-      return `'${matchString(subnode)}'`;
-    }
-    return subnode.value;
-  });
+  const defaultValues = node.nodes
+    .slice(1)
+    .filter(subnode => subnode.type !== 'div')
+    .map(subnode => {
+      if (subnode.type === 'string') {
+        return `'${matchString(subnode)}'`
+      }
+      return subnode.value
+    })
 
   if (defaultValues.length !== (node.nodes.length - 1) / 2) {
-    return null;
+    return null
   }
 
-  return `var(${variableName}, ${defaultValues.join`, `})`;
+  return `var(${variableName}, ${defaultValues.join`, `})`
 }
 
 const hexColorRe = /^(#(?:[0-9a-f]{3,4}){1,2})$/i

--- a/src/tokenTypes.js
+++ b/src/tokenTypes.js
@@ -10,6 +10,11 @@ const matchString = node => {
     .replace(/\\/g, '')
 }
 
+const matchVariable = node => {
+  if (node.type !== 'function' && node.value !== 'var') return null
+  return node.value;
+}
+
 const hexColorRe = /^(#(?:[0-9a-f]{3,4}){1,2})$/i
 const cssFunctionNameRe = /^(rgba?|hsla?|hwb|lab|lch|gray|color)$/
 
@@ -68,4 +73,5 @@ export const tokens = {
   STRING: matchString,
   COLOR: matchColor,
   LINE: regExpToken(/^(none|underline|line-through)$/i),
+  VARIABLE: matchVariable,
 }

--- a/src/tokenTypes.js
+++ b/src/tokenTypes.js
@@ -11,8 +11,26 @@ const matchString = node => {
 }
 
 const matchVariable = node => {
-  if (node.type !== 'function' && node.value !== 'var') return null
-  return node.value;
+  if (node.type !== 'function' && node.value !== 'var' || node.nodes.length === 0) return null;
+
+  const variableName = node.nodes[0].value;
+
+  if (node.nodes.length === 1) {
+    return `var(${variableName})`;
+  }
+
+  const defaultValues = node.nodes.slice(1).filter(node => node.type !== 'div').map(subnode => {
+    if (subnode.type === 'string') {
+      return `'${matchString(subnode)}'`;
+    }
+    return subnode.value;
+  });
+
+  if (defaultValues.length !== (node.nodes.length - 1) / 2) {
+    return null;
+  }
+
+  return `var(${variableName}, ${defaultValues.join`, `})`;
 }
 
 const hexColorRe = /^(#(?:[0-9a-f]{3,4}){1,2})$/i

--- a/src/transforms/fontFamily.js
+++ b/src/transforms/fontFamily.js
@@ -1,11 +1,11 @@
 import { tokens } from '../tokenTypes'
 
-const { SPACE, IDENT, STRING } = tokens
+const { SPACE, IDENT, STRING, VARIABLE } = tokens
 
 export default tokenStream => {
   let fontFamily
 
-  if (tokenStream.matches(STRING)) {
+  if (tokenStream.matches(STRING) || tokenStream.matches(VARIABLE)) {
     fontFamily = tokenStream.lastValue
   } else {
     fontFamily = tokenStream.expect(IDENT)


### PR DESCRIPTION
Currently failing when doing something like:

```css
font-family: var(--primary-font);
```

This PR fixes that, see the tests.