### PR TITLE
v2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-to-react-native",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Convert CSS text to a React Native stylesheet object",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Contains the fix for `transparent` in shorthands: 557509fc4ef01b9746262926d59a4ff339f81dcb

@jacobp100 