### PR TITLE
fix handling of flex shorthand

### DIFF
--- a/src/__tests__/flex.js
+++ b/src/__tests__/flex.js
@@ -8,19 +8,11 @@ it('transforms flex shorthand with 3 values', () => {
   })
 })
 
-it('transforms flex shorthand with 3 values in reverse order', () => {
-  expect(transformCss([['flex', '3px 1 2']])).toEqual({
-    flexGrow: 1,
-    flexShrink: 2,
-    flexBasis: 3,
-  })
-})
-
 it('transforms flex shorthand with 2 values of flex-grow and flex-shrink', () => {
   expect(transformCss([['flex', '1 2']])).toEqual({
     flexGrow: 1,
     flexShrink: 2,
-    flexBasis: 0,
+    flexBasis: 'auto',
   })
 })
 
@@ -32,19 +24,11 @@ it('transforms flex shorthand with 2 values of flex-grow and flex-basis', () => 
   })
 })
 
-it('transforms flex shorthand with 2 values of flex-grow and flex-basis (reversed)', () => {
-  expect(transformCss([['flex', '2px 2']])).toEqual({
-    flexGrow: 2,
-    flexShrink: 1,
-    flexBasis: 2,
-  })
-})
-
 it('transforms flex shorthand with 1 value of flex-grow', () => {
   expect(transformCss([['flex', '2']])).toEqual({
     flexGrow: 2,
     flexShrink: 1,
-    flexBasis: 0,
+    flexBasis: 'auto',
   })
 })
 
@@ -73,13 +57,7 @@ it('transforms flex shorthand with flex-basis set to auto', () => {
   expect(transformCss([['flex', '0 1 auto']])).toEqual({
     flexGrow: 0,
     flexShrink: 1,
-  })
-})
-
-it('transforms flex shorthand with flex-basis set to auto appearing first', () => {
-  expect(transformCss([['flex', 'auto 0 1']])).toEqual({
-    flexGrow: 0,
-    flexShrink: 1,
+    flexBasis: 'auto',
   })
 })
 
@@ -87,6 +65,7 @@ it('transforms flex auto keyword', () => {
   expect(transformCss([['flex', 'auto']])).toEqual({
     flexGrow: 1,
     flexShrink: 1,
+    flexBasis: 'auto',
   })
 })
 
@@ -94,9 +73,12 @@ it('transforms flex none keyword', () => {
   expect(transformCss([['flex', 'none']])).toEqual({
     flexGrow: 0,
     flexShrink: 0,
+    flexBasis: 'auto',
   })
 })
 
 it('does not transform invalid flex', () => {
   expect(() => transformCss([['flex', '1 2px 3']])).toThrow()
+  expect(() => transformCss([['flex', 'auto 2px 3']])).toThrow()
+  expect(() => transformCss([['flex', '2 2 2']])).toThrow()
 })

--- a/src/transforms/flex.js
+++ b/src/transforms/flex.js
@@ -4,9 +4,7 @@ const { NONE, AUTO, NUMBER, LENGTH, SPACE } = tokens
 
 const defaultFlexGrow = 1
 const defaultFlexShrink = 1
-const defaultFlexBasis = 0
-
-const FLEX_BASIS_AUTO = {} // Used for reference equality
+const defaultFlexBasis = 'auto'
 
 export default tokenStream => {
   let flexGrow
@@ -15,12 +13,20 @@ export default tokenStream => {
 
   if (tokenStream.matches(NONE)) {
     tokenStream.expectEmpty()
-    return { $merge: { flexGrow: 0, flexShrink: 0 } }
+    return {
+      $merge: { flexGrow: 0, flexShrink: 0, flexBasis: defaultFlexBasis },
+    }
   }
 
   tokenStream.saveRewindPoint()
   if (tokenStream.matches(AUTO) && !tokenStream.hasTokens()) {
-    return { $merge: { flexGrow: 1, flexShrink: 1 } }
+    return {
+      $merge: {
+        flexGrow: defaultFlexGrow,
+        flexShrink: defaultFlexGrow,
+        flexBasis: defaultFlexBasis,
+      },
+    }
   }
   tokenStream.rewind()
 
@@ -40,7 +46,7 @@ export default tokenStream => {
     } else if (flexBasis === undefined && tokenStream.matches(LENGTH)) {
       flexBasis = tokenStream.lastValue
     } else if (flexBasis === undefined && tokenStream.matches(AUTO)) {
-      flexBasis = FLEX_BASIS_AUTO
+      flexBasis = defaultFlexBasis
     } else {
       tokenStream.throw()
     }
@@ -54,7 +60,5 @@ export default tokenStream => {
   if (flexShrink === undefined) flexShrink = defaultFlexShrink
   if (flexBasis === undefined) flexBasis = defaultFlexBasis
 
-  return flexBasis !== FLEX_BASIS_AUTO
-    ? { $merge: { flexGrow, flexShrink, flexBasis } }
-    : { $merge: { flexGrow, flexShrink } }
+  return { $merge: { flexGrow, flexShrink, flexBasis } }
 }


### PR DESCRIPTION
1. the [flex spec](https://developer.mozilla.org/en-US/docs/Web/CSS/flex) doesn't allow values to be in reverse order
2. the default state of `flexBasis` should always be `"auto"`

Fixes https://github.com/styled-components/styled-components/issues/1855