### PR TITLE
Remove unitless line height

### DIFF
--- a/src/__tests__/font.js
+++ b/src/__tests__/font.js
@@ -97,15 +97,10 @@ it('omits line height if not specified', () => {
   })
 })
 
-it('allows line height as multiple', () => {
-  expect(transformCss([['font', '16px/1.5 "Helvetica"']])).toEqual({
-    fontFamily: 'Helvetica',
-    fontSize: 16,
-    fontWeight: 'normal',
-    fontStyle: 'normal',
-    fontVariant: [],
-    lineHeight: 24,
-  })
+it('does not allow line height as multiple', () => {
+  expect(() => {
+    transformCss([['font', '16px/1.5 "Helvetica"']])
+  }).toThrow()
 })
 
 it('transforms font without quotes', () => {

--- a/src/transforms/font.js
+++ b/src/transforms/font.js
@@ -4,7 +4,6 @@ import {
   SPACE,
   LENGTH,
   UNSUPPORTED_LENGTH_UNIT,
-  NUMBER,
   SLASH,
 } from '../tokenTypes'
 
@@ -46,11 +45,7 @@ export default tokenStream => {
   const fontSize = tokenStream.expect(LENGTH, UNSUPPORTED_LENGTH_UNIT)
 
   if (tokenStream.matches(SLASH)) {
-    if (tokenStream.matches(NUMBER)) {
-      lineHeight = fontSize * tokenStream.lastValue
-    } else {
-      lineHeight = tokenStream.expect(LENGTH, UNSUPPORTED_LENGTH_UNIT)
-    }
+    lineHeight = tokenStream.expect(LENGTH, UNSUPPORTED_LENGTH_UNIT)
   }
 
   tokenStream.expect(SPACE)


### PR DESCRIPTION
Since we're doing a major release anyway, I want to remove this, as it does the wrong thing in the following case,

```jsx
const Component = styled(View)`
  font: 16px/1.5 system;
`

const IncorrectLineHeight = () => (
  <Component style={{ fontSize: 24 }} />
)
```