### PR TITLE
Add types to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "Convert CSS text to a React Native stylesheet object",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "build": "rollup ./src/index.js -o index.js --f cjs && babel index.js -o index.js",
     "test": "jest",


### PR DESCRIPTION
For typescript builds, rollup/webpack will complain about not finding a type definitions file. You have one in your project so just added it to your package.json file.