### PR TITLE
add lineHeight to propertiesWithoutUnits

### DIFF
--- a/src/devPropertiesWithoutUnitsRegExp.js
+++ b/src/devPropertiesWithoutUnitsRegExp.js
@@ -5,6 +5,7 @@ if (process.env.NODE_ENV !== 'production') {
     'elevation',
     'flexGrow',
     'flexShrink',
+    'lineHeight',
     'opacity',
     'shadowOpacity',
     'zIndex',


### PR DESCRIPTION
According to [the docs](https://facebook.github.io/react-native/docs/text-style-props#lineheight), the value of `lineHeight` is a number and should not have a unit