### PR TITLE
POC: Add custom units support

### DIFF
--- a/src/__tests__/units.js
+++ b/src/__tests__/units.js
@@ -1,4 +1,4 @@
-import transformCss from '..'
+import transformCss, { declareCustomUnit } from '..'
 
 // List of units from:
 // https://developer.mozilla.org/en-US/docs/Web/CSS/length
@@ -122,6 +122,22 @@ lengthUnits.forEach(unit => {
       shadowColor: 'red',
       shadowOpacity: 1,
     })
+  })
+
+  it('allows custom units with function scaler', () => {
+    // Set rpx to scale factor 0.5
+    declareCustomUnit('rpx', size => 0.5 * size)
+
+    // Test that 2em == 28px
+    expect(transformCss([['font-size', '20rpx']])).toEqual({ fontSize: 10 })
+  })
+
+  it('allows custom units with constant scaler', () => {
+    // Set 1mpx to 14px
+    declareCustomUnit('mpx', 14)
+
+    // Test that 2mpx == 28px
+    expect(transformCss([['font-size', '2mpx']])).toEqual({ fontSize: 28 })
   })
 })
 

--- a/src/customUnits.js
+++ b/src/customUnits.js
@@ -1,0 +1,36 @@
+const customUnitRe = unit =>
+  new RegExp(`^([+-]?(?:\\d*\\.)?\\d+(?:e[+-]?\\d+)?)${unit}?$`, 'i')
+
+// Contains all the units registered via 'declareCustomUnit'
+const customUnits = []
+
+// Add a custom unit to registry
+export const declareCustomUnit = (unit, scaleValue) => {
+  customUnits.push({
+    suffix: unit,
+    regex: customUnitRe(unit),
+    scaleValue,
+  })
+}
+
+// Check if the value matches against any declared units
+export const matchesCustomUnit = token => {
+  for (let i = 0; i < customUnits.length; i += 1) {
+    const unit = customUnits[i]
+
+    // Check if string matches RegEx
+    const customUnitMatch = token.match(unit.regex)
+    if (customUnitMatch !== null) {
+      // Get number value from match result
+      const value = Number(customUnitMatch[1])
+
+      // Apply scale factor to number
+      if (typeof unit.scaleValue === 'function') {
+        return unit.scaleValue(value)
+      }
+      return value * unit.scaleValue
+    }
+  }
+
+  return null
+}

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import camelizeStyleName from 'camelize'
 import transforms from './transforms/index'
 import devPropertiesWithoutUnitsRegExp from './devPropertiesWithoutUnitsRegExp'
 import TokenStream from './TokenStream'
+import { matchesCustomUnit, declareCustomUnit } from './customUnits'
 
 // Note if this is wrong, you'll need to change tokenTypes.js too
 const numberOrLengthRe = /^([+-]?(?:\d*\.)?\d+(?:e[+-]?\d+)?)(?:px)?$/i
@@ -26,6 +27,9 @@ export const transformRawValue = (propName, value) => {
       console.warn(`Expected style "${propName}: ${value}" to be unitless`)
     }
   }
+
+  const customUnitMatch = matchesCustomUnit(value)
+  if (customUnitMatch !== null) return customUnitMatch
 
   const numberMatch = value.match(numberOrLengthRe)
   if (numberMatch !== null) return Number(numberMatch[1])
@@ -88,3 +92,5 @@ export default (rules, shorthandBlacklist = []) =>
       getStylesForProperty(propertyName, value, allowShorthand)
     )
   }, {})
+
+export { declareCustomUnit }


### PR DESCRIPTION
One of the struggles of using styled components on React Native is lack of `rem`, `vh` & `vw` support which can make styled tags full of Javascript values relying on utility functions like so:

```
const Header = styled.Text`
  font-size: ${responsiveText(14)}
`
```

or 

```
const Container = styled.Text`
  width: ${SCREEN_WIDTH}px;
`
```

This makes code IMO super messy and fragmented. Adding the ability the expand the length units for this underlying library would greatly improve developer experience. This PR adds the ability for developers to define their own custom units once for their project like so:


```
import { Dimensions} from 'react-native'
import { declareCustomUnit } from 'css-to-react-native'

// 1 rem == 16px
declareCustomUnit('rem', 16)

// 1vw = 1% of screen width
declareCustomUnit('vw', Dimensions.get('screen').width / 100)

// 1vh = 1% of screen height
declareCustomUnit('vh', Dimensions.get('screen').height / 100)
```

This registers those units so that they can be used throughout the RN project:

```
const HeaderText = styled.Text`
  color: ${props => props.theme.fontColor};
  font-size: 1.5rem;
  font-family: ${props => props.theme.sansFont};
`
```