### PR TITLE
Adds `line-height` to list of props without units

### DIFF
--- a/src/devPropertiesWithoutUnitsRegExp.js
+++ b/src/devPropertiesWithoutUnitsRegExp.js
@@ -8,6 +8,7 @@ if (process.env.NODE_ENV !== 'production') {
     'opacity',
     'shadowOpacity',
     'zIndex',
+    'lineHeight',
   ]
 }
 


### PR DESCRIPTION
I am currently [getting an error](https://codesandbox.io/p/sandbox/inspiring-platform-y8do8d?file=%2Findex.js&selection=%5B%7B%22endColumn%22%3A1%2C%22endLineNumber%22%3A4%2C%22startColumn%22%3A1%2C%22startLineNumber%22%3A4%7D%5D) when using `line-height` without a unit which is allowed https://developer.mozilla.org/en-US/docs/Web/CSS/line-height