### PR TITLE
feat: add native RtL css support

### DIFF
--- a/src/__tests__/boxModel.js
+++ b/src/__tests__/boxModel.js
@@ -15,6 +15,19 @@ it('transforms margin, padding with 1 value', () => {
   })
 })
 
+// RTL
+it('transforms margin-inline-start with marginStart', () => {
+  expect(transformCss([['margin-inline-start', '1px']])).toEqual({
+    marginStart: 1,
+  })
+})
+
+it('transforms start with start', () => {
+  expect(transformCss([['start', '1px']])).toEqual({
+    start: 1,
+  })
+})
+
 it('transforms margin, padding with 2 values', () => {
   expect(transformCss([['margin', '1px 2px']])).toEqual({
     marginTop: 1,
@@ -116,6 +129,8 @@ it('transforms margin shorthand with auto', () => {
     marginLeft: 'auto',
   })
 })
+
+
 
 it('transforms border width', () => {
   expect(transformCss([['border-width', '1px 2px 3px 4px']])).toEqual({

--- a/src/index.js
+++ b/src/index.js
@@ -52,12 +52,12 @@ const transformShorthandValue =
   process.env.NODE_ENV === 'production'
     ? baseTransformShorthandValue
     : (propName, value) => {
-        try {
-          return baseTransformShorthandValue(propName, value)
-        } catch (e) {
-          throw new Error(`Failed to parse declaration "${propName}: ${value}"`)
-        }
+      try {
+        return baseTransformShorthandValue(propName, value)
+      } catch (e) {
+        throw new Error(`Failed to parse declaration "${propName}: ${value}"`)
       }
+    }
 
 export const getStylesForProperty = (propName, inputValue, allowShorthand) => {
   const isRawValue = allowShorthand === false || !(propName in transforms)
@@ -70,12 +70,21 @@ export const getStylesForProperty = (propName, inputValue, allowShorthand) => {
   return propValues
 }
 
+const cssRtLToNativeCamelized = {
+  "margin-inline-start": "marginStart",
+  "margin-inline-end": "marginEnd",
+  "padding-inline-start": "paddingStart",
+  "padding-inline-end": "paddingEnd",
+  "inset-inline-start": "start",
+  "inset-inline-end": "end"
+}
+
 export const getPropertyName = propName => {
   const isCustomProp = /^--\w+/.test(propName)
   if (isCustomProp) {
     return propName
   }
-  return camelizeStyleName(propName)
+  return cssRtLToNativeCamelized[propName] || camelizeStyleName(propName)
 }
 
 export default (rules, shorthandBlacklist = []) =>


### PR DESCRIPTION
### Why
It was decided the ```I18nManager.forceRtL(true)``` does nothing on Web, hence rendering RtL handling between native/non-native very difficult using properties like margin-left/margin-right (mobile flips whereas web doesn't).

With this change, we can write RtL sensitive properties that will work across native (i.e. Mobile) and non-native (i.e. Web) platforms and allow for the components be re-used with the same strategy (more on that below) since RN does not understand ```marginInlineStart``` for example.
```ts
<HeadingContainer style={{ marginInlineStart: 10, start: 5}}>
```

### Proposition
This PR would essentially allows us to write non-native css properties like so:
```ts
const HeadingContainer = styled.View`
  margin-inline-start: 20;
  inset-inline-start: 5 ;
`;
```
which would in turn be converted to accepted native css and applied like so:
```ts
<HeadingContainer style={{ marginStart: 10, start: 5}}>
```

It is worth nothing that this works without any code change but is less than ideal suggestion to mix native with non-native css:
```ts
const HeadingContainer = styled.View`
  margin-start: 20;
  start: 5 ;
`;
```

### Strategy
- For Web, it is then possible to set RtL on RtL sensitive css by applying ```dir="rtl"``` on a highest top level RN parent in the tree which will force all children to take on rtl.
- On mobile, continue using  ```I18nManager.forceRtL(true)```

### Notes
Minimal code change/tests since the root issue is still be discussed