### PR TITLE
Fix accumulating spread in transform function

### DIFF
--- a/.changeset/calm-clocks-battle.md
+++ b/.changeset/calm-clocks-battle.md
@@ -1,0 +1,5 @@
+---
+'css-to-react-native': patch
+---
+
+Refactor transform to avoid accumulator-based object merging.

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,15 +105,20 @@ export const getPropertyName = (propName: string): string => {
 const transform = (
   rules: StyleTuple[],
   shorthandBlacklist: string[] = []
-): Style =>
-  rules.reduce<Style>((accum, rule) => {
+): Style => {
+  const result: Style = {}
+
+  for (const rule of rules) {
     const propertyName = getPropertyName(rule[0])
     const value = rule[1]
     const allowShorthand = shorthandBlacklist.indexOf(propertyName) === -1
-    return Object.assign(
-      accum,
+    Object.assign(
+      result,
       getStylesForProperty(propertyName, value, allowShorthand)
     )
-  }, {})
+  }
+
+  return result
+}
 
 export default transform


### PR DESCRIPTION
Spread syntax should be avoided on accumulators (like those in `.reduce`) because it causes a time complexity of `O(n^2)`.